### PR TITLE
Add png support for loop and add support for blackmagic sdi mode

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -92,25 +92,14 @@ def mk_video_src(args, videocaps):
             """
                 # startx=0 starty=0 endx=1919 endy=1079 !
 
-    elif args.video_source == 'blackmagichdmi':
+    elif args.video_source == 'blackmagic':
 
-        video_args['mode'] = args.video_arg if args.video_arg else "17"
-
-        video_src = """
-            decklinkvideosrc mode={mode} connection=2 !
-                {monitor}
-		videoconvert !
-                yadif !
-                videorate !
-                videoscale !
-            """
-
-    elif args.video_source == 'blackmagicsdi':
-
-        video_args['mode'] = args.video_arg if args.video_arg else "17"
+        mode, connection = args.video_arg.split(':')
+        video_args['mode'] = mode
+        video_args['connection'] = connection
 
         video_src = """
-            decklinkvideosrc mode={mode} connection=1 !
+            decklinkvideosrc mode={mode} connection{connection} !
                 {monitor}
 		videoconvert !
                 yadif !
@@ -119,10 +108,12 @@ def mk_video_src(args, videocaps):
             """
 
     elif args.video_source == 'png':
+
         file, start, stop = args.video_arg.split(':')
         video_args['file'] = file
         video_args['start'] = start
         video_args['stop'] = stop
+
         video_src = """
             multifilesrc
                 loop=1
@@ -179,12 +170,7 @@ def mk_audio_src(args, audiocaps):
                 alsasrc {audio_device} name=audiosrc !
                 """.format(audio_device=audio_device)
 
-    elif args.audio_source == 'blackmagichdmi':
-        audio_src = """
-            decklinkaudiosrc !
-            """
-
-    elif args.audio_source == 'blackmagicsdi':
+    elif args.audio_source == 'blackmagic':
         audio_src = """
             decklinkaudiosrc !
             """
@@ -300,8 +286,8 @@ def get_args():
 
     parser.add_argument( '--video-source', action='store', 
             choices=[
-                'dv', 'hdv', 'hdmi2usb', 'blackmagichdmi',
-                'blackmagicsdi', 'ximage', 'png', 'test'], 
+                'dv', 'hdv', 'hdmi2usb', 'blackmagic',
+                'ximage', 'png', 'test'], 
             default='test',
             help="Where to get video from")
 
@@ -312,8 +298,7 @@ def get_args():
             help="misc video arg for gst whatever")
 
     parser.add_argument( '--audio-source', action='store', 
-            choices=['dv', 'alsa', 'pulse', 'blackmagichdmi',
-                     'blackmagicsdi', 'test'], 
+            choices=['dv', 'alsa', 'pulse', 'blackmagic', 'test'], 
             default='test',
             help="Where to get audio from")
 

--- a/ingest.py
+++ b/ingest.py
@@ -99,7 +99,7 @@ def mk_video_src(args, videocaps):
         video_args['connection'] = connection
 
         video_src = """
-            decklinkvideosrc mode={mode} connection{connection} !
+            decklinkvideosrc mode={mode} connection={connection} !
                 {monitor}
 		videoconvert !
                 yadif !

--- a/ingest.py
+++ b/ingest.py
@@ -118,6 +118,22 @@ def mk_video_src(args, videocaps):
                 videoscale !
             """
 
+    elif args.video_source == 'png':
+        file, start, stop = args.video_arg.split(':')
+        video_args['file'] = file
+        video_args['start'] = start
+        video_args['stop'] = stop
+        video_src = """
+            multifilesrc
+                loop=1
+                location={file}
+                start-index={start}
+                stop-index={stop}
+                caps="image/png,framerate=25/1" !
+            pngdec !
+            videoconvert !
+            """
+
     elif args.video_source == 'test':
 
         video_args['pattern'] = args.video_arg if args.video_arg else "ball"
@@ -285,7 +301,7 @@ def get_args():
     parser.add_argument( '--video-source', action='store', 
             choices=[
                 'dv', 'hdv', 'hdmi2usb', 'blackmagichdmi',
-                'blackmagicsdi', 'ximage', 'test'], 
+                'blackmagicsdi', 'ximage', 'png', 'test'], 
             default='test',
             help="Where to get video from")
 

--- a/ingest.py
+++ b/ingest.py
@@ -120,7 +120,7 @@ def mk_video_src(args, videocaps):
                 location={file}
                 start-index={start}
                 stop-index={stop}
-                caps="image/png,framerate=25/1" !
+                caps="image/png !
             pngdec !
             videoconvert !
             """

--- a/ingest.py
+++ b/ingest.py
@@ -100,6 +100,7 @@ def mk_video_src(args, videocaps):
             decklinkvideosrc mode={mode} connection=2 !
                 {monitor}
 		videoconvert !
+                yadif !
                 videorate !
                 videoscale !
             """

--- a/ingest.py
+++ b/ingest.py
@@ -105,6 +105,19 @@ def mk_video_src(args, videocaps):
                 videoscale !
             """
 
+    elif args.video_source == 'blackmagicsdi':
+
+        video_args['mode'] = args.video_arg if args.video_arg else "17"
+
+        video_src = """
+            decklinkvideosrc mode={mode} connection=1 !
+                {monitor}
+		videoconvert !
+                yadif !
+                videorate !
+                videoscale !
+            """
+
     elif args.video_source == 'test':
 
         video_args['pattern'] = args.video_arg if args.video_arg else "ball"
@@ -151,6 +164,11 @@ def mk_audio_src(args, audiocaps):
                 """.format(audio_device=audio_device)
 
     elif args.audio_source == 'blackmagichdmi':
+        audio_src = """
+            decklinkaudiosrc !
+            """
+
+    elif args.audio_source == 'blackmagicsdi':
         audio_src = """
             decklinkaudiosrc !
             """
@@ -266,9 +284,8 @@ def get_args():
 
     parser.add_argument( '--video-source', action='store', 
             choices=[
-                'dv', 'hdv', 'hdmi2usb', 'blackmagichdmi', 
-                'ximage',
-                'test', ], 
+                'dv', 'hdv', 'hdmi2usb', 'blackmagichdmi',
+                'blackmagicsdi', 'ximage', 'test'], 
             default='test',
             help="Where to get video from")
 
@@ -279,7 +296,8 @@ def get_args():
             help="misc video arg for gst whatever")
 
     parser.add_argument( '--audio-source', action='store', 
-            choices=['dv', 'alsa', 'pulse', 'blackmagichdmi', 'test'], 
+            choices=['dv', 'alsa', 'pulse', 'blackmagichdmi',
+                     'blackmagicsdi', 'test'], 
             default='test',
             help="Where to get audio from")
 


### PR DESCRIPTION
This pull adds the ability to use pngs in a folder to create a loop. You can use it this way:

```
ingest.py --video-source png --video-arg <dirname/file%03d.png>:start:stop>
```

Where `start` is the number of the first file and `stop` is the number of the last one.

The `blackmagichdmi` video source also has been changed to `blackmagic`. The goal is to support the SDI mode of the card. You now have to explicitly tell what connection you should use:

```
ingest.py --video-source blackmagic --video-arg 11:2
```

Where `11` is the mode and `2` is the connection.
