### PR TITLE
fix a channel issue

### DIFF
--- a/record-timestamp.sh
+++ b/record-timestamp.sh
@@ -9,7 +9,7 @@ mkdir -p $dest_dir/$(date +%Y-%m-%d)
 
 ffmpeg \
 	-i tcp://$VOC_CORE:11000 \
-	-ac 2 -channel_layout 2 -aspect 16:9 \
+	-ac 2 -channel_layout 2c -aspect 16:9 \
         -map 0:v -c:v:0 mpeg2video -pix_fmt:v:0 yuv422p -qscale:v:0 2 -qmin:v:0 2 -qmax:v:0 10 -keyint_min 0 -bf:0 0 -g:0 0 -intra:0 -maxrate:0 140M \
         -map 0:a -c:a:0 mp2 -b:a:0 192k -ac:a:0 2 -ar:a:0 48000 \
         -flags +global_header -flags +ilme+ildct \


### PR DESCRIPTION
ffmpeg complains about not using the right channel parameter:

> Single channel layout '2' is interpreted as a number of channels, switch to the syntax '2c' otherwise it will be interpreted as a channel layout number in a later version

This fixes it.
