### PR TITLE
Support raw-video UVC capture devices

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -59,8 +59,7 @@ def mk_video_src(args, videocaps):
         decodebin !
             """
 
-    elif args.video_source == 'hdmi2usb':
-        # https://hdmi2usb.tv
+    elif args.video_source in ('hdmi2usb', 'uvc-mjpeg'):
         video_src = """
             v4l2src {attribs} name=videosrc !
         """
@@ -395,8 +394,8 @@ def get_args():
     parser.add_argument(
         '--video-source', action='store',
         choices=[
-            'dv', 'hdv', 'udp_h264', 'hdmi2usb', 'blackmagic',
-            'ximage', 'png', 'file', 'rtmp', 'test', 'spacescope'],
+            'dv', 'hdv', 'udp_h264', 'hdmi2usb', 'uvc-mjpeg',
+            'blackmagic', 'ximage', 'png', 'file', 'rtmp', 'test', 'spacescope'],
         default='test',
         help="Where to get video from")
 

--- a/ingest.py
+++ b/ingest.py
@@ -61,13 +61,14 @@ def mk_video_src(args, videocaps):
 
     elif args.video_source == 'hdmi2usb':
         # https://hdmi2usb.tv
-        # Note: this code works with 720p
         video_src = """
             v4l2src {attribs} name=videosrc !
+        """
+        video_src += """
                 queue max-size-time=4000000000 !
-        image/jpeg,width=1280,height=720 !
+        image/jpeg,{caps} !
                 jpegdec !
-            """
+            """.format(caps=extract_caps(videocaps))
 
     elif args.video_source == 'ximage':
         # startx=0 starty=0 endx=1919 endy=1079 !
@@ -208,6 +209,13 @@ def mk_audio_src(args, audiocaps):
     audio_src = audio_src.format(**d)
 
     return audio_src
+
+
+def extract_caps(videocaps, caps=("width", "height")):
+    """Filter out caps (list of keys) from a videocaps strings"""
+    parts = videocaps.split(',')
+    filtered = [cap for cap in parts if cap.split('=')[0] in caps]
+    return ','.join(filtered)
 
 
 def mk_client(core_ip, port):

--- a/ingest.py
+++ b/ingest.py
@@ -69,6 +69,16 @@ def mk_video_src(args, videocaps):
                 jpegdec !
             """.format(caps=extract_caps(videocaps))
 
+    elif args.video_source == 'uvc-raw':
+
+        video_src = """
+            v4l2src {attribs} name=videosrc !
+        """
+        video_src += """
+        video/x-raw,{caps} !
+        """.format(
+            caps=extract_caps(videocaps))
+
     elif args.video_source == 'ximage':
         # startx=0 starty=0 endx=1919 endy=1079 !
         video_src = """
@@ -394,7 +404,7 @@ def get_args():
     parser.add_argument(
         '--video-source', action='store',
         choices=[
-            'dv', 'hdv', 'udp_h264', 'hdmi2usb', 'uvc-mjpeg',
+            'dv', 'hdv', 'udp_h264', 'hdmi2usb', 'uvc-mjpeg', 'uvc-raw',
             'blackmagic', 'ximage', 'png', 'file', 'rtmp', 'test', 'spacescope'],
         default='test',
         help="Where to get video from")


### PR DESCRIPTION
Like the ASUS CU4K30 that we're experimenting with.

In the process, make the `hdmi2usb` source more generic, determine the frame size from the server caps.