### PR TITLE
Exec ffmpeg so we can shut down cleanly

### DIFF
--- a/record-timestamp.sh
+++ b/record-timestamp.sh
@@ -27,7 +27,7 @@ segment_time=1800  # 30 min
 
 mkdir -p $dest_dir/$(date +%Y-%m-%d)
 
-ffmpeg \
+exec ffmpeg \
     -nostdin -y \
     -analyzeduration 10000 \
     -thread_queue_size 512 \


### PR DESCRIPTION
Don't leave a useless bash intersposing between mintor-stdout and ffmpeg. This allows SIGINT to make its way to ffmpeg and shut down the recording gracefully